### PR TITLE
Hide date if field is empty

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,9 @@
   <article>
     <header>
       <h1>{{ .Title }}</h1>
-      <time datetime="{{ .Date }}">{{ .Date.Format ("January 2, 2006") }}</time>
+      {{ with .Date}}
+        <time datetime="{{ . }}">{{ .Format ("January 2, 2006") }}</time>
+      {{ end }}
     </header>
     {{ .Content }}
   </article>


### PR DESCRIPTION
fix #2 

Use [`with`](https://gohugo.io/functions/with/) to only display date when field is populated in the post front matter.