### PR TITLE
Article header prominence  

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -54,9 +54,6 @@
     </style>
   </head>
   <body>
-    <header>
-      <h1><a href="/">{{ .Site.Title }}</a></h1>
-    </header>
     {{ block "main" . }}{{ end }}
     <footer>
       <hr>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+<header>
+  <h1><a href="/">{{ .Site.Title }}</a></h1>
+</header>
 <main>
   <ul>
     {{ range .Pages }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+<header>
+  <p style="font-weight:900;font-style:italic;float:right;"><a href="/">{{ .Site.Title }}</a></p>
+</header>
 <main>
   <article>
     <header>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,6 +9,7 @@
       {{ with .Date}}
         <time datetime="{{ . }}">{{ .Format ("January 2, 2006") }}</time>
       {{ end }}
+      <hr>
     </header>
     {{ .Content }}
   </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
 <main>
   <article>
     <header>
-      <h1>{{ .Title }}</h1>
+      <h1 style="font-size:2em;">{{ .Title }}</h1>
       {{ with .Date}}
         <time datetime="{{ . }}">{{ .Format ("January 2, 2006") }}</time>
       {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+<header>
+  <h1><a href="/">{{ .Site.Title }}</a></h1>
+</header>
 <main>
   <ul>
     {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}


### PR DESCRIPTION
fix #1 

Give prominence to article headers.

- Move page header out of `baseof.html` so it can be styled based on page type
- On `single.html`
  - remove `H1` from page header and float to right
  - Override size of article `H1`
  - add hr